### PR TITLE
Add a missing dependency to Dates. Export write_to_png.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,3 +5,4 @@ version = "0.1.0"
 
 [deps]
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/CairoPlot.jl
+++ b/src/CairoPlot.jl
@@ -4,6 +4,7 @@ using Cairo
 using Dates
 
 export crplot
+export write_to_png
 
 include("main.jl")
 


### PR DESCRIPTION
Small update to your work! It is working and we don't depend anymore on Python and PyPlot (and Plots actually ...)

Please merge it when you can. I will point the bot to my fork in the meantime.